### PR TITLE
Minor Changes

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,21 @@
+name: gradle-ci
+
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+    - name: Build artifacts
+      run: ./gradlew build
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v1
+      with:
+        name: build-artifacts
+        path: build/libs

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -12,9 +12,11 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 11
-    - name: Build artifacts
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+    - name: Build With Gradle
       run: ./gradlew build
-    - name: Upload build artifacts
+    - name: Upload Build Artifacts
       uses: actions/upload-artifact@v1
       with:
         name: build-artifacts

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Update Suppression Block
 
-This is a carpet extension, so it requires https://github.com/gnembon/fabric-carpet to run
+This is a carpet extension, so it requires [Fabric Carpet](https://github.com/gnembon/fabric-carpet) to run.
 
 The mod adds the carpet rule: `updateSuppressionBlock` which when turned on makes it so that an activator rail above a barrier block causes a stack overflow.

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '0.4-SNAPSHOT'
+	id 'fabric-loom' version '0.6-SNAPSHOT'
 	id 'maven-publish'
 }
 

--- a/src/main/java/updatesuppressionblock/UpdateSuppressionBlockSettings.java
+++ b/src/main/java/updatesuppressionblock/UpdateSuppressionBlockSettings.java
@@ -6,7 +6,9 @@ import static carpet.settings.RuleCategory.CREATIVE;
 
 public class UpdateSuppressionBlockSettings
 {
-    @Rule(desc = "UpdateSuppressionBlock", category = {CREATIVE, "extras"})
+    @Rule(
+            desc = "Placing an activator rail on top of a barrier block will update suppress when the rail turns off.",
+            category = {CREATIVE, "extras"}
+    )
     public static boolean updateSuppressionBlock = false;
-
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,16 +1,17 @@
 {
   "schemaVersion": 1,
   "id": "updatesuppressionblock",
-  "version": "1.0.1",
+  "version": "${version}",
 
   "name": "Update Suppression Block",
-  "description": "Placing an Activator Rail ontop of a barrier block will update suppress when the rail turns off",
+  "description": "Placing an Activator Rail on top of a barrier block will update suppress when the rail turns off",
   "authors": [
     "PR0CESS"
   ],
   "contact": {
-    "homepage": "https://web.me/",
-    "sources": "https://github.com/"
+    "homepage": "https://github.com/fxmorin/UpdateSuppressionBlock",
+    "sources": "https://github.com/fxmorin/UpdateSuppressionBlock",
+    "issues": "https://github.com/fxmorin/UpdateSuppressionBlock/issues"
   },
 
   "license": "CC0-1.0",
@@ -30,8 +31,5 @@
     "minecraft": "1.16.x",
     "fabricloader": ">=0.10.0",
     "carpet": "*"
-  },
-  "suggests": {
-    "flamingo": "*"
   }
 }

--- a/src/main/resources/updatesuppressionblock.mixins.json
+++ b/src/main/resources/updatesuppressionblock.mixins.json
@@ -5,7 +5,6 @@
   "mixins": [
     "BarrierBlockMixin"
   ],
-  "client": [],
   "injectors": {
     "defaultRequire": 1
   }


### PR DESCRIPTION
- fabric.mod.json:
  - fix typo
  - add links
  - remove useless flamingo thing
  - added an automatic version thing which sets the version to whatever it is in `gradle.properties`, so you don't have to manually change it

- bumped loom version so that it builds on jdk 16 (note that it will still not work if you run `gradlew build`, only if you install gradle 7.0-rc1 on your computer and build with that (`gradle build`), but if you use jdk 16, it probably won't be too difficult to use gradle 7.0-rc1).
- added github actions to build on push, in case any more changes are added to this mod
- remove useless 'client' part from the mixins json file
- more detailed carpet rule description
- use markdown formatting for link in README